### PR TITLE
resize root partition on first boot

### DIFF
--- a/board/common/overlay/init
+++ b/board/common/overlay/init
@@ -66,7 +66,7 @@ then
   ROOT_START=$(parted -s $BOOT_DISK unit MiB print | awk '/^ *1 / {print $2}' | tr -d 'MiB')
   ROOT_END=$(parted -s $BOOT_DISK unit MiB print | awk '/^ *1 / {print $3}' | tr -d 'MiB')
   ROOT_SIZE=$(echo "$ROOT_END - $ROOT_START" | bc)
-  NEW_ROOT_SIZE=$(echo "$ROOT_SIZE * 0.1" | bc | cut -d. -f1)
+  NEW_ROOT_SIZE=$(echo "$ROOT_SIZE * 2" | bc | cut -d. -f1)
   NEW_ROOT_END=$(echo "$ROOT_END + $NEW_ROOT_SIZE" | bc | cut -d. -f1)
   parted --fix -s $BOOT_DISK resizepart $ROOT_PART_NUM "${NEW_ROOT_END}MiB"
 


### PR DESCRIPTION
this will resize the root partition before creating the overlay partition.
This will give to rootfs space to grwo.
If wee grow out of space we can just remove overlay and quash and init will grwo root again.