### PR TITLE
upload development build to buildroot-snapshot release

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -88,9 +88,9 @@ jobs:
       - name: Create/Update Latest Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: latest
+          tag_name: buildroot-snapshot
           body: |
-            Latest development build from master branch
+            Snapshot development build from master branch
             Commit: ${{ github.sha }}
           files: artifacts/**/*
           prerelease: true

--- a/board/common/overlay/sbin/sysupgrade
+++ b/board/common/overlay/sbin/sysupgrade
@@ -36,7 +36,7 @@ download_firmware() {
 		gzip -d "$archive" -c | tar xf - -C /tmp && echo_c 32 "Local archive unpacked" || die "Cannot extract $archive"
 		rm $archive
 	else
-		[ -z "$url" ] && url=$(get_system_upgrade || echo "https://github.com/OpenIPC/sbc-groundstations/releases/download/latest/${defconfig}.tar.gz")
+		[ -z "$url" ] && url=$(get_system_upgrade || echo "https://github.com/OpenIPC/sbc-groundstations/releases/download/buildroot-snapshot/${defconfig}.tar.gz")
 		echo "Download from $url"
 		[ "$(curl -o /dev/null -s -k -w '%{http_code}\n' "$url")" = "000" ] && die "Check your network!"
 		curl --connect-timeout 30 -s -k -m 120 -L "$url" -s -o - | gzip -d | tar xf - -C /tmp && echo_c 32 "Received and unpacked" || die "Cannot retrieve $url"

--- a/board/common/post-build-script.sh
+++ b/board/common/post-build-script.sh
@@ -3,7 +3,7 @@
 eval $(grep BR2_DEFCONFIG ${O}/.config)
 echo "BUILD_CONFIG=$(basename $(basename $BR2_DEFCONFIG) _defconfig)" >> $TARGET_DIR/etc/os-release
 
-DOWNLOAD_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-OpenIPC/sbc-groundstations}/releases/download/latest/$(basename $(basename $BR2_DEFCONFIG) _defconfig).tar.gz"
+DOWNLOAD_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-OpenIPC/sbc-groundstations}/releases/download/buildroot-snapshot/$(basename $(basename $BR2_DEFCONFIG) _defconfig).tar.gz"
 echo "UPGRADE=$DOWNLOAD_URL" >> $TARGET_DIR/etc/os-release
 
 echo "BUILD_DATE=\"$(date)\"" >> $TARGET_DIR/etc/os-release


### PR DESCRIPTION
Currently, images are uploaded to the release created based on the "latest" tag. I believe this might lead to the misconception that the image in "latest" is the latest stable version, when in reality it's just a development snapshot.

I think the "latest" tag release should contain the latest release versions of all editions, while  buildroot edition development versions should be stored in the "buildroot-snapshot" tag release. What do you think @henkwiedig 

```
# edition snapshot tag and snapshot releases
buildroot-snapshot
CC-snapshot
stock-snapshot
etc.-snapshot

# edition version tag and version releases
buildroot-v1.0
stock-v1.9.9
CC-v1.0-alpha
etc.-vx.0

# latest tag and release
Links to the latest version release and snapshot release for all editions.
```
********************************************************************
