### PR TITLE
add proper pixelpilot build dependencies

### DIFF
--- a/package/pixelpilot/pixelpilot.mk
+++ b/package/pixelpilot/pixelpilot.mk
@@ -10,7 +10,7 @@ PIXELPILOT_SITE_METHOD = git
 PIXELPILOT_GIT_SUBMODULES = YES
 PIXELPILOT_INSTALL_STAGING = NO
 PIXELPILOT_INSTALL_TARGET = YES
-PIXELPILOT_DEPENDENCIES = rockchip-mpp
+PIXELPILOT_DEPENDENCIES = rockchip-mpp libdrm cairo spdlog json-for-modern-cpp yaml-cpp libgpiod gstreamer1 gst1-plugins-base msgpack
 
 PIXELPILOT_CMAKE_OPTS += -DCMAKE_PREFIX_PATH=$(STAGING_DIR)/usr
 


### PR DESCRIPTION
Needed to build pixelpilot useing `./build.sh pixelpilot-rebuild` without building the whole image.