### PR TITLE
CI: set working directory to /mnt/workspace

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,6 +28,10 @@ jobs:
           - emax_wyvern-link
 
     steps:
+
+      - name: Display free disk space
+        run: df -hT
+
       - name: Checkout source
         uses: actions/checkout@v4
 
@@ -37,6 +41,9 @@ jobs:
           echo "CACHE_DATE=$(date +%m)" >> $GITHUB_ENV
           sudo apt update
           sudo apt install -y cpio rsync bc qemu-user-static binfmt-support
+          sudo mkdir -p /mnt/workspace
+          sudo chown $USER:$USER /mnt/workspace
+          rsync -a "$GITHUB_WORKSPACE/" /mnt/workspace/
 
       - name: Setup ccache
         uses: actions/cache@v4
@@ -45,6 +52,7 @@ jobs:
           key: ${{ matrix.platform }}-${{ env.CACHE_DATE }}
 
       - name: Build firmware
+        working-directory: /mnt/workspace
         run: |
           export GIT_HASH=$(git rev-parse --short $GITHUB_SHA)
           export GIT_BRANCH=${GITHUB_REF_NAME}
@@ -62,11 +70,11 @@ jobs:
         with:
           name: ${{ matrix.platform }}-images-${{ github.sha }}
           path: |
-            output/${{ matrix.platform }}_defconfig/images/${{ matrix.platform }}_sdcard.img
-            output/${{ matrix.platform }}_defconfig/images/${{ matrix.platform }}_u-boot.bin
-            output/${{ matrix.platform }}_defconfig/images/${{ matrix.platform }}_emmc_bootloader.img
-            output/${{ matrix.platform }}_defconfig/images/${{ matrix.platform }}_rootfs.squashfs
-            output/${{ matrix.platform }}_defconfig/images/${{ matrix.platform }}.tar.gz
+            /mnt/workspace/output/${{ matrix.platform }}_defconfig/images/${{ matrix.platform }}_sdcard.img
+            /mnt/workspace/output/${{ matrix.platform }}_defconfig/images/${{ matrix.platform }}_u-boot.bin
+            /mnt/workspace/output/${{ matrix.platform }}_defconfig/images/${{ matrix.platform }}_emmc_bootloader.img
+            /mnt/workspace/output/${{ matrix.platform }}_defconfig/images/${{ matrix.platform }}_rootfs.squashfs
+            /mnt/workspace/output/${{ matrix.platform }}_defconfig/images/${{ matrix.platform }}.tar.gz
           retention-days: 7
 
   release-on-master:


### PR DESCRIPTION
I notice github action runner have another disk /dev/sda1 and mounted to /mnt with 60G+ avail space, we can set working directory to /mnt/workspace and never have to worry about insufficient storage space again.

```
Run df -hT
Filesystem     Type   Size  Used Avail Use% Mounted on
/dev/root      ext4    72G   55G   18G  76% /
tmpfs          tmpfs  7.9G   84K  7.9G   1% /dev/shm
tmpfs          tmpfs  3.2G  1.2M  3.2G   1% /run
tmpfs          tmpfs  5.0M     0  5.0M   0% /run/lock
/dev/sdb16     ext4   881M   62M  758M   8% /boot
/dev/sdb15     vfat   105M  6.2M   99M   6% /boot/efi
/dev/sda1      ext4    74G  4.1G   66G   6% /mnt
tmpfs          tmpfs  1.6G   12K  1.6G   1% /run/user/1001
```