### PR TITLE
Add modprobe config to fix g_ether OTG ethernet on macOS/iPadOS

### DIFF
--- a/board/common/overlay/etc/modprobe.d/g_ether.conf
+++ b/board/common/overlay/etc/modprobe.d/g_ether.conf
@@ -1,0 +1,1 @@
+options g_ether use_eem=0


### PR DESCRIPTION
EEM mode is not supported by macOS or iPadOS. Setting use_eem=0 forces CDC Ethernet mode, which is compatible with both platforms.

This enables native streaming to Mac/iOS using the OTG port.