### PR TITLE
multifix: boot fix, PixelPilot defaults, 20 MHz, component bumps

### DIFF
--- a/board/common/overlay/init
+++ b/board/common/overlay/init
@@ -149,7 +149,7 @@ if [ -n "$GADGET_MODE_GPIO" ]; then
     GADGET_MODE_GPIO_STATE=$(gpioget $GADGET_MODE_GPIO)
   fi
 fi
-if [ "$(gpioget $GADGET_MODE_GPIO_STATE)" = "1" ]
+if [ "$GADGET_MODE_GPIO_STATE" = "1" ]
 then
   echo '<0>gadget_mode: #####################################################################' > /dev/kmsg
   echo '<0>gadget_mode: #                                                                   #' > /dev/kmsg

--- a/package/msposd/0001-buildroot.patch
+++ b/package/msposd/0001-buildroot.patch
@@ -1,8 +1,8 @@
-diff -ur a/Makefile b/Makefile
---- a/Makefile	2025-11-05 20:34:01.119164171 +0100
-+++ b/Makefile	2025-11-05 21:23:16.146826771 +0100
+diff -ru a/Makefile b/Makefile
+--- a/Makefile	2026-06-21 23:01:41.000000000 +0200
++++ b/Makefile	2026-07-08 21:57:45.043726364 +0200
 @@ -70,3 +70,10 @@
- 	$(eval LIB = `pkg-config --libs cairo x11` -lm -lrt)
+ 	$(eval LIB = `pkg-config --libs cairo x11 xext` -lXext -lm -lrt)
  	$(eval BUILD = $(CC) $(SRCS) -I $(SDK)/include -L $(DRV) $(CFLAGS) $(LIB) -levent_core -O0 -g -o $(OUTPUT))
  	$(BUILD)
 +
@@ -12,67 +12,58 @@ diff -ur a/Makefile b/Makefile
 +	$(eval LIB = `pkg-config --libs cairo` -lm -lrt)
 +	$(eval BUILD = $(CC) $(SRCS) -I $(SDK)/include -L $(TARGET_LD) $(CFLAGS) $(LIB) -levent_core -O0 -g -o $(OUTPUT) -Wno-incompatible-pointer-types)
 +	$(BUILD)
-\ Kein Zeilenumbruch am Dateiende.
-diff -ur a/osd/util/Render_gs.c b/osd/util/Render_gs.c
---- a/osd/util/Render_gs.c	2025-11-05 20:34:01.215162650 +0100
-+++ b/osd/util/Render_gs.c	2025-11-05 21:12:25.321344018 +0100
-@@ -1,15 +1,15 @@
+diff -ru a/msposd.c b/msposd.c
+--- a/msposd.c	2026-06-21 23:01:41.000000000 +0200
++++ b/msposd.c	2026-07-08 22:05:27.923209484 +0200
+@@ -31,6 +31,8 @@
+ //#include "osd/msp_displayport_mux.c"
+ #include "osd/net/network.h"
+ 
++void trace_fragment(bool reset);
++
+ #include "osd.c" //Should be merged
+ 
+ //#include "msp/msp.cpp"
+diff -ru a/osd/util/Render_gs.c b/osd/util/Render_gs.c
+--- a/osd/util/Render_gs.c	2026-06-21 23:01:41.000000000 +0200
++++ b/osd/util/Render_gs.c	2026-07-08 22:05:26.139242289 +0200
+@@ -1,9 +1,11 @@
  #include "../../bmp/bitmap.h"
--#include <X11/Xatom.h>
--#include <X11/Xlib.h>
--#include <X11/Xutil.h>
--#include <cairo/cairo-xlib.h>
-+// #include <X11/Xatom.h>
-+// #include <X11/Xlib.h>
-+// #include <X11/Xutil.h>
-+// #include <cairo/cairo-xlib.h>
++#if defined(_x86)
+ #include <X11/Xatom.h>
+ #include <X11/Xlib.h>
+ #include <X11/Xutil.h>
+ #include <X11/extensions/XShm.h>
+ #include <cairo/cairo-xlib.h>
++#endif
  #include <cairo/cairo.h>
  #include <stdio.h>
  #include <stdlib.h>
- #include <string.h>
- #include <unistd.h>
+@@ -17,7 +19,9 @@
+ #include <sys/ipc.h>
+ #include <sys/shm.h>
  
--#include <X11/keysym.h>
-+// #include <X11/keysym.h>
++#if defined(_x86)
+ #include <X11/keysym.h>
++#endif
  #include <event2/event.h>
+ #include "simple_ini.h"
  
- #if defined(_x86)
-@@ -394,6 +394,7 @@
- extern float Transform_Pitch;
- bool outlined = true;
+@@ -84,9 +88,9 @@
  
-+#if defined(_x86)
- void drawLineGS(int x0, int y0, int x1, int y1, uint32_t color, double thickness, bool Transpose) {
+ extern bool verbose;
  
- 	if (Transpose) {
-@@ -462,6 +463,7 @@
- 		cairo_restore(cr);
- 	}
- }
-+#endif
- 
- // Function to draw rotated text with rotation
- int getTextWidth(const char *text, double size) {
-@@ -485,6 +487,7 @@
- 	// Set the color using RGBA values (each between 0.0 and 1.0)
- 	cairo_set_source_rgba(cr, r, g, b, a);
+-#if defined(_x86)
+ void rotate_point(Point original, Point img_center, double angle_degrees, Point *rotated);
  
 +#if defined(_x86)
- 	if (Transpose) {
- 		uint32_t width = Transform_OVERLAY_WIDTH;
- 		uint32_t height = Transform_OVERLAY_HEIGHT;
-@@ -503,6 +506,7 @@
- 		x = rotated_pos.x;
- 		y = rotated_pos.y;
- 	}
-+#endif
+ void handle_key_press(XEvent *event) {
+ 	KeySym keysym = XLookupKeysym(&event->xkey, 0); // Map keycode to keysym
  
- 	cairo_set_font_size(cr, size);
- 
-diff -ur a/osd.c b/osd.c
---- a/osd.c	2025-11-05 20:34:01.211162713 +0100
-+++ b/osd.c	2025-11-05 21:21:08.192889713 +0100
-@@ -723,9 +723,11 @@
+diff -ru a/osd.c b/osd.c
+--- a/osd.c	2026-06-21 23:01:41.000000000 +0200
++++ b/osd.c	2026-07-08 21:57:24.758099929 +0200
+@@ -779,9 +779,11 @@
  
  void LineDirect(uint8_t *bmpData, uint32_t width, uint32_t height, int x0, int y0, int x1, int y1,
  	uint8_t color, int thickness) {
@@ -85,7 +76,7 @@ diff -ur a/osd.c b/osd.c
  #else
  	drawLineI4(bmpData, width, height, x0, y0, x1, y1, color, thickness);
  #endif
-@@ -733,8 +735,10 @@
+@@ -789,8 +791,10 @@
  
  void LineTranspose(
  	uint8_t *bmpData, int posX0, int posY0, int posX1, int posY1, uint8_t color, int thickness) {

--- a/package/msposd/msposd.mk
+++ b/package/msposd/msposd.mk
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-MSPOSD_VERSION = 694221a59e4b17fd4324d24337a7bf3293127dcf
+MSPOSD_VERSION = 27ae3a0779fe2d7148a8d775c4313c321c0f6d1d
 MSPOSD_SITE = https://github.com/OpenIPC/msposd.git
 MSPOSD_SITE_METHOD = git
 MSPOSD_INSTALL_TARGET = YES

--- a/package/pixelpilot/files/gsmenu.sh
+++ b/package/pixelpilot/files/gsmenu.sh
@@ -661,7 +661,7 @@ case "$@" in
     "get gs system rx_codec")
         . /etc/default/pixelpilot
         echo $PIXELPILOT_CODEC
-        emit_values "h264\nh265"
+        emit_values "h264\nh265\nauto"
         ;;
     "get gs system rx_mode")
         . /etc/default/wifibroadcast

--- a/package/pixelpilot/files/pixelpilot
+++ b/package/pixelpilot/files/pixelpilot
@@ -2,6 +2,7 @@ PIXELPILOT_OSD_CONFIG_FILE="$([ -f /media/dvr/osd.json ] && echo /media/dvr/osd.
 PIXELPILOT_OSD_ARGS="--osd --osd-custom-message --osd-config $PIXELPILOT_OSD_CONFIG_FILE"
 PIXELPILOT_CONFIG_YAML="$([ -f /media/dvr/pixelpilot.yaml ] && echo /media/dvr/pixelpilot.yaml || echo /etc/pixelpilot.yaml)"
 PIXELPILOT_SCREEN_MODE="1920x1080@60"
+PIXELPILOT_DISABLE_VSYNC="--disable-vsync"
 PIXELPILOT_DVR_FRAMERATE="60"
 PIXELPILOT_CODEC="h265"
 PIXELPILOT_VIDEO_SCALE=1.0
@@ -14,4 +15,4 @@ PIXELPILOT_DVR_RESOLUTION="1080p"
 PIXELPILOT_DVR_MODE="reencode"
 PIXELPILOT_DVR_MAX_SIZE="4000"
 
-PIXELPILOT_ARGS="--config $PIXELPILOT_CONFIG_YAML $PIXELPILOT_OSD_ARGS --codec $PIXELPILOT_CODEC --screen-mode $PIXELPILOT_SCREEN_MODE --video-scale $PIXELPILOT_VIDEO_SCALE --dvr-framerate $PIXELPILOT_DVR_FRAMERATE --dvr-fmp4 --dvr-sequenced-files --dvr-template /media/dvr/record_%Y-%m-%d_%H-%M-%S.mp4 $PIXELPILOT_LIVE_COLORTRANS --dvr-reenc-codec $PIXELPILOT_DVR_CODEC --dvr-reenc-bitrate $PIXELPILOT_DVR_BITRATE --dvr-reenc-fps $PIXELPILOT_DVR_FPS $PIXELPILOT_DVR_OSD --dvr-reenc-resolution $PIXELPILOT_DVR_RESOLUTION --dvr-mode $PIXELPILOT_DVR_MODE --dvr-max-size $PIXELPILOT_DVR_MAX_SIZE"
+PIXELPILOT_ARGS="--config $PIXELPILOT_CONFIG_YAML $PIXELPILOT_OSD_ARGS $PIXELPILOT_DISABLE_VSYNC --codec $PIXELPILOT_CODEC --screen-mode $PIXELPILOT_SCREEN_MODE --video-scale $PIXELPILOT_VIDEO_SCALE --dvr-framerate $PIXELPILOT_DVR_FRAMERATE --dvr-fmp4 --dvr-sequenced-files --dvr-template /media/dvr/record_%Y-%m-%d_%H-%M-%S.mp4 $PIXELPILOT_LIVE_COLORTRANS --dvr-reenc-codec $PIXELPILOT_DVR_CODEC --dvr-reenc-bitrate $PIXELPILOT_DVR_BITRATE --dvr-reenc-fps $PIXELPILOT_DVR_FPS $PIXELPILOT_DVR_OSD --dvr-reenc-resolution $PIXELPILOT_DVR_RESOLUTION --dvr-mode $PIXELPILOT_DVR_MODE --dvr-max-size $PIXELPILOT_DVR_MAX_SIZE"

--- a/package/pixelpilot/files/pixelpilot.sh
+++ b/package/pixelpilot/files/pixelpilot.sh
@@ -3,7 +3,7 @@
 while true
 do
   test -r /etc/default/pixelpilot && . /etc/default/pixelpilot
-  /usr/bin/pixelpilot $PIXELPILOT_ARGS
+  /usr/bin/pixelpilot $PIXELPILOT_ARGS "$@"
   rc=$?
   if [ $rc = 2 -o $rc = 143 -o $rc = 137 ]
   then

--- a/package/rockchip-mpp/rockchip-mpp.mk
+++ b/package/rockchip-mpp/rockchip-mpp.mk
@@ -1,5 +1,5 @@
-ROCKCHIP_MPP_VERSION = develop
-ROCKCHIP_MPP_SITE = https://github.com/HermanChen/mpp.git
+ROCKCHIP_MPP_VERSION = c2c1ee502b3a26efebcf843f7a0aeb4d172c6237
+ROCKCHIP_MPP_SITE = https://github.com/rockchip-linux/mpp.git
 ROCKCHIP_MPP_SITE_METHOD = git
 ROCKCHIP_MPP_INSTALL_STAGING = YES
 ROCKCHIP_MPP_INSTALL_TARGET = YES

--- a/package/rtl8812au/rtl8812au.mk
+++ b/package/rtl8812au/rtl8812au.mk
@@ -2,7 +2,7 @@
 # RTL8812AU package (external kernel)
 ################################################################################
 
-RTL8812AU_VERSION = 7bccd51541dd505270d322a7da3b9feccc910393
+RTL8812AU_VERSION = be10cbbbd9b6b5325554a06a0132985a6b890175
 RTL8812AU_SITE = https://github.com/svpcom/rtl8812au
 RTL8812AU_SITE_METHOD = git
 RTL8812AU_LICENSE = unspecified

--- a/package/rtl88x2cu/rtl88x2cu.mk
+++ b/package/rtl88x2cu/rtl88x2cu.mk
@@ -2,7 +2,7 @@
 # RTL88X2CU package (external kernel)
 ################################################################################
 
-RTL88X2CU_VERSION = bb70f25eb836cb52a7fa572a07d94ab5b9e7dd6c
+RTL88X2CU_VERSION = 132c1e32b93c0678c01e631bfb9d014a575eeb13
 RTL88X2CU_SITE = https://github.com/libc0607/rtl88x2cu-20230728.git
 RTL88X2CU_SITE_METHOD = git
 RTL88X2CU_LICENSE = unspecified

--- a/package/rtl88x2eu/rtl88x2eu.mk
+++ b/package/rtl88x2eu/rtl88x2eu.mk
@@ -2,7 +2,7 @@
 # RTL88X2EU package (external kernel)
 ################################################################################
 
-RTL88X2EU_VERSION = a8fe2bb8b01650fa451ae7c38bf641259f43a83e
+RTL88X2EU_VERSION = 48e6e449e089fa954e4e15079bd864039e2960da
 RTL88X2EU_SITE = https://github.com/libc0607/rtl88x2eu-20230815.git
 RTL88X2EU_SITE_METHOD = git
 RTL88X2EU_LICENSE = unspecified

--- a/package/wfb-server/0001-setup.py.patch
+++ b/package/wfb-server/0001-setup.py.patch
@@ -7,8 +7,8 @@
 -version = os.environ.get('VERSION')
 -commit = os.environ.get('COMMIT')
 -install_data_files = not bool(os.environ.get('OMIT_DATA_FILES'))
-+version = '25.5.1'
-+commit = '7ffc689e3f1194dca79dca4b5b56ee560c0cc3be'
++version = '1.2.3'
++commit = 'a23fc969d50d1f50bdcac46815848105dd0e88c9'
 +install_data_files = False
  
  assert version and commit

--- a/package/wfb-server/0002-per-service-log-interval.patch
+++ b/package/wfb-server/0002-per-service-log-interval.patch
@@ -1,15 +1,15 @@
---- a/wfb_ng/services.py	2025-10-30 17:41:25.041984643 +0100
-+++ b/wfb_ng/services.py	2025-11-06 17:25:17.857505191 +0100
-@@ -124,7 +124,7 @@
+--- a/wfb_ng/services.py	2026-07-08 21:05:07.255717179 +0200
++++ b/wfb_ng/services.py	2026-07-08 21:13:20.798759362 +0200
+@@ -126,7 +126,7 @@
                  fec_timeout=cfg.fec_timeout,
                  fec_delay=cfg.fec_delay,
                  link_id=link_id,
 -                log_interval=settings.common.log_interval,
 +                log_interval=getattr(cfg, 'log_interval', settings.common.log_interval),
                  rcv_buf_size=settings.common.tx_rcv_buf_size,
-                 snd_buf_size=settings.common.rx_snd_buf_size)
-            ).split() + wlans
-@@ -167,7 +167,7 @@
+                 snd_buf_size=settings.common.rx_snd_buf_size,
+                 injection_retries=cfg.injection_retries,
+@@ -171,7 +171,7 @@
                  key=os.path.join(settings.path.conf_dir, cfg.keypair),
                  rcv_buf_size=settings.common.tx_rcv_buf_size,
                  snd_buf_size=settings.common.rx_snd_buf_size,
@@ -18,7 +18,7 @@
                  link_id=link_id)).split() + (wlans if not is_cluster else [])
  
      df = RXProtocol(ant_sel_f, cmd, '%s rx' % (service_name,)).start()
-@@ -251,7 +251,7 @@
+@@ -255,7 +255,7 @@
                     key=os.path.join(settings.path.conf_dir, cfg.keypair),
                     rcv_buf_size=settings.common.tx_rcv_buf_size,
                     snd_buf_size=settings.common.rx_snd_buf_size,
@@ -27,7 +27,7 @@
                     link_id=link_id)).split() + (wlans if not is_cluster else [])
  
      tx_socket_path = '%s-tx-%s' % (service_name, os.urandom(4).hex())
-@@ -279,7 +279,7 @@
+@@ -283,7 +283,7 @@
                     fec_timeout=cfg.fec_timeout,
                     fec_delay=cfg.fec_delay,
                     link_id=link_id,
@@ -36,7 +36,7 @@
                     rcv_buf_size=settings.common.tx_rcv_buf_size,
                     snd_buf_size=settings.common.rx_snd_buf_size)).split() + wlans
  
-@@ -365,7 +365,7 @@
+@@ -369,7 +369,7 @@
                     key=os.path.join(settings.path.conf_dir, cfg.keypair),
                     rcv_buf_size=settings.common.tx_rcv_buf_size,
                     snd_buf_size=settings.common.rx_snd_buf_size,
@@ -45,7 +45,7 @@
                     link_id=link_id)).split() + (wlans if not is_cluster else [])
  
      tx_socket_path = '%s-tx-%s' % (service_name, os.urandom(4).hex())
-@@ -393,7 +393,7 @@
+@@ -397,7 +397,7 @@
                     fec_timeout=cfg.fec_timeout,
                     fec_delay=cfg.fec_delay,
                     link_id=link_id,
@@ -54,7 +54,7 @@
                     rcv_buf_size=settings.common.tx_rcv_buf_size,
                     snd_buf_size=settings.common.rx_snd_buf_size)).split() + wlans
  
-@@ -484,7 +484,7 @@
+@@ -488,7 +488,7 @@
                         key=os.path.join(settings.path.conf_dir, cfg.keypair),
                         rcv_buf_size=settings.common.tx_rcv_buf_size,
                         snd_buf_size=settings.common.rx_snd_buf_size,
@@ -63,7 +63,7 @@
                         link_id=link_id)).split() + (wlans if not is_cluster else [])
  
          log.msg('%s RX: %s' % (service_name, ' '.join(cmd_rx)))
-@@ -516,7 +516,7 @@
+@@ -520,7 +520,7 @@
                         fec_timeout=cfg.fec_timeout,
                         fec_delay=cfg.fec_delay,
                         link_id=link_id,

--- a/package/wfb-server/wfb-server.mk
+++ b/package/wfb-server/wfb-server.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-WFB_SERVER_VERSION = 7ffc689e3f1194dca79dca4b5b56ee560c0cc3be
+WFB_SERVER_VERSION = a23fc969d50d1f50bdcac46815848105dd0e88c9
 WFB_SERVER_SITE = https://github.com/svpcom/wfb-ng.git
 WFB_SERVER_SITE_METHOD = git
 WFB_SERVER_LICENSE = GPL-3.0
@@ -18,7 +18,7 @@ WFB_SERVER_PYTHON_DEPENDENCIES = \
 
 WFB_SERVER_BUILD_ENV = \
     VERSION=25.5.1 \
-    COMMIT=7ffc689e3f1194dca79dca4b5b56ee560c0cc3be \
+    COMMIT=a23fc969d50d1f50bdcac46815848105dd0e88c9 \
     OMIT_DATA_FILES=True
 
 $(eval $(python-package))

--- a/package/wifibroadcast-ng/files/wifibroadcast.cfg
+++ b/package/wifibroadcast-ng/files/wifibroadcast.cfg
@@ -12,7 +12,7 @@ peer = 'connect://127.0.0.1:14550'  # outgoing connection
 log_interval = 100
 peer = 'connect://127.0.0.1:5600'  # outgoing connection for
                                    # video sink (QGroundControl on GS)
-bandwidth = 40
+bandwidth = 20
 
 [gs_tunnel]
 ldpc = 1

--- a/package/wifibroadcast-ng/wifibroadcast-ng.mk
+++ b/package/wifibroadcast-ng/wifibroadcast-ng.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-WIFIBROADCAST_NG_VERSION = 7ffc689e3f1194dca79dca4b5b56ee560c0cc3be
+WIFIBROADCAST_NG_VERSION = a23fc969d50d1f50bdcac46815848105dd0e88c9
 WIFIBROADCAST_NG_SITE = https://github.com/svpcom/wfb-ng.git
 WIFIBROADCAST_NG_SITE_METHOD = git
 WIFIBROADCAST_NG_LICENSE = GPL-3.0


### PR DESCRIPTION
# Fixes
- **Gadget mode on boot**: `GADGET_MODE_GPIO_STATE` was passed into a second `gpioget`, so the check never worked — now compares the variable directly.

# PixelPilot
- Default to `--disable-vsync`.
- Forward extra args through `pixelpilot.sh` (`"$@"`).
- Add `auto` as an `rx_codec` menu option (h264 / h265 / auto).

# wfb-ng
- Default bandwidth 40 → 20 MHz.
- Bump wfb-server + wifibroadcast-ng → `a23fc96`.

# Version bumps
- rockchip-mpp: `develop` → `c2c1ee5` (pinned)
- rtl8812au → `be10cbb`, rtl88x2cu → `132c1e3`, rtl88x2eu → `48e6e44`
- msposd → `27ae3a0` (refreshed buildroot patch)
