### PR TITLE
pp_rk: bump to latest fixes, extend osd.json

### DIFF
--- a/board/openipc/bonnet/overlay/etc/pixelpilot/osd.json
+++ b/board/openipc/bonnet/overlay/etc/pixelpilot/osd.json
@@ -23,7 +23,7 @@
             "x": -250,
             "y": 0,
             "facts": [
-                {"name": "os_mon.wifi.rssi", "tags": {"type": "rssi_a"}}
+                {"name": "os_mon.wifi.rssi", "tags": {"adapter": "0", "type": "rssi_a"}}
             ],
             "ranges_and_icons": [
                 {"range": [70, 100], "icon_path": "signal1.png"},
@@ -42,7 +42,7 @@
             "x": -205,
             "y": 0,
             "facts": [
-                {"name": "os_mon.wifi.rssi", "tags": {"type": "rssi_b"}}
+                {"name": "os_mon.wifi.rssi", "tags": {"adapter": "0", "type": "rssi_b"}}
             ],
             "ranges_and_icons": [
                 {"range": [70, 100], "icon_path": "signal1.png"},

--- a/package/pixelpilot/files/gsmenu.sh
+++ b/package/pixelpilot/files/gsmenu.sh
@@ -1200,9 +1200,14 @@ EOF
         exit 1
         ;;
 esac
+rc=$?
 
-case $? in
+case "$1" in
+    set|button) sync ;;
+esac
+
+case $rc in
     0) ;;
     1) exit 0 ;;
-    *) exit $? ;;
+    *) exit $rc ;;
 esac

--- a/package/pixelpilot/files/osd.json
+++ b/package/pixelpilot/files/osd.json
@@ -23,7 +23,7 @@
             "x": -250,
             "y": 0,
             "facts": [
-                {"name": "os_mon.wifi.rssi", "tags": {"type": "rssi_a"}}
+                {"name": "os_mon.wifi.rssi", "tags": {"adapter": "0", "type": "rssi_a"}}
             ],
             "ranges_and_icons": [
                 {"range": [70, 100], "icon_path": "signal1.png"},
@@ -42,7 +42,7 @@
             "x": -205,
             "y": 0,
             "facts": [
-                {"name": "os_mon.wifi.rssi", "tags": {"type": "rssi_b"}}
+                {"name": "os_mon.wifi.rssi", "tags": {"adapter": "0", "type": "rssi_b"}}
             ],
             "ranges_and_icons": [
                 {"range": [70, 100], "icon_path": "signal1.png"},
@@ -170,6 +170,58 @@
             ]
         },
         {
+            "name": "WFBNG RF temperature adapter 1",
+            "type": "---IconTplTextWidget",
+            "x": -250,
+            "y": 155,
+            "icon_path": "device_thermostat.png",
+            "template": "RF %u°C / %u°C",
+            "___comment": "BoxWidget height above needs to be 165",
+            "facts": [
+                {"name": "wfbcli.rf_temperature", "tags": {"ant_id": "0"}},
+                {"name": "wfbcli.rf_temperature", "tags": {"ant_id": "256"}}
+            ]
+        },
+        {
+            "name": "APFPV WiFi RF temperature adapter 1",
+            "type": "---IconTplTextWidget",
+            "x": -250,
+            "y": 155,
+            "icon_path": "device_thermostat.png",
+            "template": "RF %i°C / %i°C",
+            "___comment": "BoxWidget height above needs to be 165",
+            "facts": [
+                {"name": "os_mon.wifi.temperature", "tags": {"adapter": "0", "rf_path": "0"}},
+                {"name": "os_mon.wifi.temperature", "tags": {"adapter": "0", "rf_path": "1"}}
+            ]
+        },
+        {
+            "name": "APFPV WiFi RF temperature adapter 2",
+            "type": "---IconTplTextWidget",
+            "x": -250,
+            "y": 185,
+            "icon_path": "device_thermostat.png",
+            "template": "RF %i°C / %i°C",
+            "___comment": "BoxWidget height above needs to be 195",
+            "facts": [
+                {"name": "os_mon.wifi.temperature", "tags": {"adapter": "1", "rf_path": "0"}},
+                {"name": "os_mon.wifi.temperature", "tags": {"adapter": "1", "rf_path": "1"}}
+            ]
+        },
+        {
+            "name": "APFPV WiFi RF temperature adapter 3",
+            "type": "---IconTplTextWidget",
+            "x": -250,
+            "y": 215,
+            "icon_path": "device_thermostat.png",
+            "template": "RF %i°C / %i°C",
+            "___comment": "BoxWidget height above needs to be 225",
+            "facts": [
+                {"name": "os_mon.wifi.temperature", "tags": {"adapter": "2", "rf_path": "0"}},
+                {"name": "os_mon.wifi.temperature", "tags": {"adapter": "2", "rf_path": "1"}}
+            ]
+        },
+        {
             "type": "IconSelectorWidget",
             "name": "No signal icon",
             "x": -250,
@@ -217,6 +269,19 @@
                     "__comment": "Should be sum per-second, scaled to Megs",
                     "name": "gstreamer.received_bytes"
                 }
+            ]
+        },
+        {
+            "name": "Video codec",
+            "type": "IconSelectorWidget",
+            "x": -80,
+            "y": 65,
+            "facts": [
+                { "name": "video.codec_id" }
+            ],
+            "ranges_and_icons": [
+                { "range": [0, 0], "icon_path": "h264.png" },
+                { "range": [1, 1], "icon_path": "h265.png" }
             ]
         },
         {

--- a/package/pixelpilot/pixelpilot.mk
+++ b/package/pixelpilot/pixelpilot.mk
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-PIXELPILOT_VERSION=09b85b31242f2a6d818781a7c2a0ce2c41cdb849
+PIXELPILOT_VERSION=47e21fb43fe68c9fe43771d630d6c36d06755120
 PIXELPILOT_SITE=https://github.com/OpenIPC/PixelPilot_rk.git
 PIXELPILOT_SITE_METHOD = git
 PIXELPILOT_GIT_SUBMODULES = YES


### PR DESCRIPTION
Bump pp_rk to the latest fixes:
- https://github.com/OpenIPC/PixelPilot_rk/pull/144
- https://github.com/OpenIPC/PixelPilot_rk/pull/145
- https://github.com/OpenIPC/PixelPilot_rk/pull/146

Extend osd.json with examples how to use the new temperature readings as commented out "---IconTplTextWidget" widgets.
User will have to manually enable theses as they are currently not generalizable and depend on hardware and RXMODE.